### PR TITLE
Add considerations per product

### DIFF
--- a/doc/test_description.template.rst
+++ b/doc/test_description.template.rst
@@ -46,5 +46,31 @@ this refers to the publisher/subscriber applications. Qos policies are set
 to the corresponding entity: DomainParticipant, Publisher, Subscriber, Topic,
 DataWriter or DataReader.
 
+Considerations per Product
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+This section outlines important considerations for different products, including
+default values, features enabled or disabled, and unsupported features.
+
+* **Connext**:
+  * Content Filtered Topic expression created with single quotes around strings
+    values
+* **FastDDS**:
+  * Content Filtered Topic expression created with single quotes around strings
+    values
+* **InteroCOM DDS**:
+  * Content Filtered Topic expression created with single quotes around strings
+    values
+* **OpenDDS**:
+  * Content Filtered Topic expression created without single quotes around
+    strings values
+  * Disabled XTypes Support
+* **CoreDX DDS**:
+  * Content Filtered Topic expression created without single quotes around
+    strings values
+  * Disabled writer-side content filter
+  * DataReader send_initial_nack enabled
+  * DataReader precache_max_samples set to 0
+  * Set environment variable `COREDX_UDP_RX_BUFFER_SIZE` to `65536`
+
 
 |TEST_DESCRIPTION|

--- a/doc/test_description.template.rst
+++ b/doc/test_description.template.rst
@@ -48,8 +48,13 @@ DataWriter or DataReader.
 
 Considerations per Product
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 This section outlines important considerations for different products, including
 default values, features enabled or disabled, and unsupported features.
+
+Note that there is no version number because these changes applies to all
+versions.
+
 
 * **Connext**:
 
@@ -61,7 +66,7 @@ default values, features enabled or disabled, and unsupported features.
   * Content Filtered Topic expression created with single quotes around strings
     values
 
-* **InteroCOM DDS**:
+* **InterCOM DDS**:
 
   * Content Filtered Topic expression created with single quotes around strings
     values

--- a/doc/test_description.template.rst
+++ b/doc/test_description.template.rst
@@ -56,7 +56,7 @@ Note that there is no version number because these changes apply to all
 product versions.
 
 
-* **Connext**:
+* **Connext DDS**:
 
   * Content Filtered Topic expression created with single quotes around strings
     values

--- a/doc/test_description.template.rst
+++ b/doc/test_description.template.rst
@@ -52,7 +52,7 @@ Considerations per Product
 This section outlines important considerations for different products, including
 default values, features enabled or disabled, and unsupported features.
 
-Note that there is no version number because these changes applies to all
+Note that there is no version number because these changes apply to all
 versions.
 
 

--- a/doc/test_description.template.rst
+++ b/doc/test_description.template.rst
@@ -53,7 +53,7 @@ This section outlines important considerations for different products, including
 default values, features enabled or disabled, and unsupported features.
 
 Note that there is no version number because these changes apply to all
-versions.
+product versions.
 
 
 * **Connext**:
@@ -85,7 +85,7 @@ versions.
   * DataReader `send_initial_nack` enabled that sends an initial NACK to every
     discovered DataWriter (only when using reliable RELIABILITY)
   * DataReader `precache_max_samples` set to 0 that sets to 0 the number of
-    samples pre-cached
+    samples pre-cached (only when using reliable RELIABILITY)
   * Set environment variable `COREDX_UDP_RX_BUFFER_SIZE` to `65536` that
     increases the buffer sizes to that value
 

--- a/doc/test_description.template.rst
+++ b/doc/test_description.template.rst
@@ -81,10 +81,13 @@ versions.
 
   * Content Filtered Topic expression created without single quotes around
     strings values
-  * Disabled writer-side content filter
-  * DataReader send_initial_nack enabled
-  * DataReader precache_max_samples set to 0
-  * Set environment variable `COREDX_UDP_RX_BUFFER_SIZE` to `65536`
+  * Disabled writer-side content filtering
+  * DataReader `send_initial_nack` enabled that sends an initial NACK to every
+    discovered DataWriter (only when using reliable RELIABILITY)
+  * DataReader `precache_max_samples` set to 0 that sets to 0 the number of
+    samples pre-cached
+  * Set environment variable `COREDX_UDP_RX_BUFFER_SIZE` to `65536` that
+    increases the buffer sizes to that value
 
 
 |TEST_DESCRIPTION|

--- a/doc/test_description.template.rst
+++ b/doc/test_description.template.rst
@@ -52,19 +52,28 @@ This section outlines important considerations for different products, including
 default values, features enabled or disabled, and unsupported features.
 
 * **Connext**:
+
   * Content Filtered Topic expression created with single quotes around strings
     values
+
 * **FastDDS**:
+
   * Content Filtered Topic expression created with single quotes around strings
     values
+
 * **InteroCOM DDS**:
+
   * Content Filtered Topic expression created with single quotes around strings
     values
+
 * **OpenDDS**:
+
   * Content Filtered Topic expression created without single quotes around
     strings values
   * Disabled XTypes Support
+
 * **CoreDX DDS**:
+
   * Content Filtered Topic expression created without single quotes around
     strings values
   * Disabled writer-side content filter

--- a/generate_xlsx_report.py
+++ b/generate_xlsx_report.py
@@ -69,7 +69,7 @@ class ProductUtils:
         """Returns a beautified product name and version"""
         # set the beautified name and version
         if 'connext' in product.lower():
-            return 'Connext ' + re.search(r'([\d.]+)', product).group(1)
+            return 'Connext DDS' + re.search(r'([\d.]+)', product).group(1)
         elif 'opendds' in product.lower():
             return 'OpenDDS ' + re.search(r'([\d.]+)', product).group(1)
         elif 'coredx' in product.lower():
@@ -661,8 +661,8 @@ class XlsxReport:
             'Publisher/Subscriber', self.__formats['bold_w_border'])
 
         # create a dictionary to store the row/column of the product name
-        # for example, row_dict['Connext 6.1.2'] = 30 means that the
-        # row (publisher) of Connext 6.1.2 is in the xlsx row 29.
+        # for example, row_dict['Connext DDS 6.1.2'] = 30 means that the
+        # row (publisher) of Connext DDS 6.1.2 is in the xlsx row 29.
         # Column for the publisher is always fixed: 1 --> B
         # Row for the subscriber is always fixed: current_row
         subscriber_row = current_row


### PR DESCRIPTION
This PR adds to the documentation a new section about "considerations per product", such as changes in the default behavior, things that are different depending on the product, etc...

This is related to a previous discussion we had, but instead of having it as part of the spreadsheet, it is a section in the documentation.