### PR TITLE
Improve ownership tests

### DIFF
--- a/interoperability_report.py
+++ b/interoperability_report.py
@@ -161,7 +161,7 @@ def run_subscriber_shape_main(
                 # to the Subscriber. By default it does not check
                 # anything and returns ReturnCode.OK.
                 produced_code[produced_code_index] = check_function(
-                    child_sub, samples_sent, timeout)
+                    child_sub, samples_sent, last_sample_saved, timeout)
 
     subscriber_finished.set()   # set subscriber as finished
     log_message(f'Subscriber {subscriber_index}: Waiting for Publishers to '

--- a/interoperability_report.py
+++ b/interoperability_report.py
@@ -33,6 +33,7 @@ def run_subscriber_shape_main(
         produced_code_index: int,
         subscriber_index: int,
         samples_sent: "list[multiprocessing.Queue]",
+        last_sample_saved: "list[multiprocessing.Queue]",
         verbosity: bool,
         timeout: int,
         file: tempfile.TemporaryFile,
@@ -56,6 +57,9 @@ def run_subscriber_shape_main(
         samples_sent <<in>>: list of multiprocessing Queues with the samples
                 the Publishers send. Element 1 of the list is for
                 Publisher 1, etc.
+        last_sample_saved <<in>>: list of multiprocessing Queues with the last
+                sample saved on samples_sent for each Publisher. Element 1 of
+                the list is for Publisher 1, etc.
         verbosity <<in>>: print debug information.
         timeout <<in>>: time pexpect waits until it matches a pattern.
         file <<inout>>: temporal file to save shape_main application output.
@@ -470,6 +474,7 @@ def run_test(
                         'produced_code_index':i,
                         'subscriber_index':subscriber_number+1,
                         'samples_sent':samples_sent,
+                        'last_sample_saved':last_sample_saved,
                         'verbosity':verbosity,
                         'timeout':timeout,
                         'file':temporary_file[i],

--- a/rtps_test_utilities.py
+++ b/rtps_test_utilities.py
@@ -50,5 +50,5 @@ def remove_ansi_colors(text):
     cleaned_str = ansi_escape.sub('', text)
     return cleaned_str
 
-def no_check(child_sub, samples_sent, timeout):
+def no_check(child_sub, samples_sent, last_sample_saved, timeout):
     return ReturnCode.OK

--- a/test_suite.py
+++ b/test_suite.py
@@ -48,7 +48,7 @@ import time
 # is received in order, or that OWNERSHIP works properly, etc...
 MAX_SAMPLES_READ = 500
 
-def test_ownership_receivers(child_sub, samples_sent, timeout):
+def test_ownership_receivers(child_sub, samples_sent, last_sample_saved, timeout):
 
     """
     This function is used by test cases that have two publishers and one subscriber.
@@ -63,6 +63,9 @@ def test_ownership_receivers(child_sub, samples_sent, timeout):
     samples_sent: list of multiprocessing Queues with the samples
                 the publishers send. Element 1 of the list is for
                 publisher 1, etc.
+    last_sample_saved: list of multiprocessing Queues with the last
+            sample saved on samples_sent for each Publisher. Element 1 of
+            the list is for Publisher 1, etc.
     timeout: time pexpect waits until it matches a pattern.
 
     This functions assumes that the subscriber has already received samples
@@ -172,7 +175,7 @@ def test_ownership_receivers(child_sub, samples_sent, timeout):
     print(f'Samples read: {samples_read}')
     return ReturnCode.RECEIVING_FROM_ONE
 
-def test_color_receivers(child_sub, samples_sent, timeout):
+def test_color_receivers(child_sub, samples_sent, last_sample_saved, timeout):
 
     """
     This function is used by test cases that have two publishers and one
@@ -182,6 +185,7 @@ def test_color_receivers(child_sub, samples_sent, timeout):
 
     child_sub: child program generated with pexpect
     samples_sent: not used
+    last_sample_saved: not used
     timeout: time pexpect waits until it matches a pattern.
     """
     sub_string = re.search('\w\s+(\w+)\s+[0-9]+ [0-9]+ \[[0-9]+\]',
@@ -217,13 +221,14 @@ def test_color_receivers(child_sub, samples_sent, timeout):
     print(f'Samples read: {samples_read}')
     return ReturnCode.RECEIVING_FROM_ONE
 
-def test_reliability_order(child_sub, samples_sent, timeout):
+def test_reliability_order(child_sub, samples_sent, last_sample_saved, timeout):
     """
     This function tests reliability, it checks whether the subscriber receives
     the samples in order.
 
     child_sub: child program generated with pexpect
     samples_sent: not used
+    last_sample_saved: not used
     timeout: not used
     """
 
@@ -267,7 +272,7 @@ def test_reliability_order(child_sub, samples_sent, timeout):
     return produced_code
 
 
-def test_reliability_no_losses(child_sub, samples_sent, timeout):
+def test_reliability_no_losses(child_sub, samples_sent, last_sample_saved, timeout):
     """
     This function tests RELIABLE reliability, it checks whether the subscriber
     receives the samples in order and with no losses.
@@ -276,6 +281,7 @@ def test_reliability_no_losses(child_sub, samples_sent, timeout):
     samples_sent: list of multiprocessing Queues with the samples
                 the publishers send. Element 1 of the list is for
                 publisher 1, etc.
+    last_sample_saved: not used
     timeout: time pexpect waits until it matches a pattern.
     """
 
@@ -352,7 +358,7 @@ def test_reliability_no_losses(child_sub, samples_sent, timeout):
     return produced_code
 
 
-def test_durability_volatile(child_sub, samples_sent, timeout):
+def test_durability_volatile(child_sub, samples_sent, last_sample_saved, timeout):
     """
     This function tests the volatile durability, it checks that the sample the
     subscriber receives is not the first one. The publisher application sends
@@ -365,6 +371,7 @@ def test_durability_volatile(child_sub, samples_sent, timeout):
 
     child_sub: child program generated with pexpect
     samples_sent: not used
+    last_sample_saved: not used
     timeout: not used
     """
 
@@ -387,7 +394,7 @@ def test_durability_volatile(child_sub, samples_sent, timeout):
 
     return produced_code
 
-def test_durability_transient_local(child_sub, samples_sent, timeout):
+def test_durability_transient_local(child_sub, samples_sent, last_sample_saved, timeout):
     """
     This function tests the TRANSIENT_LOCAL durability, it checks that the
     sample the subscriber receives is the first one. The publisher application
@@ -396,6 +403,7 @@ def test_durability_transient_local(child_sub, samples_sent, timeout):
 
     child_sub: child program generated with pexpect
     samples_sent: not used
+    last_sample_saved: not used
     timeout: not used
     """
 
@@ -416,7 +424,7 @@ def test_durability_transient_local(child_sub, samples_sent, timeout):
     return produced_code
 
 
-def test_deadline_missed(child_sub, samples_sent, timeout):
+def test_deadline_missed(child_sub, samples_sent, last_sample_saved, timeout):
     """
     This function tests whether the subscriber application misses the requested
     deadline or not. This is needed in case the subscriber application receives
@@ -424,6 +432,7 @@ def test_deadline_missed(child_sub, samples_sent, timeout):
 
     child_sub: child program generated with pexpect
     samples_sent: not used
+    last_sample_saved: not used
     timeout: time pexpect waits until it matches a pattern
     """
 

--- a/test_suite.py
+++ b/test_suite.py
@@ -116,6 +116,8 @@ def test_ownership_receivers(child_sub, samples_sent, last_sample_saved, timeout
         except queue.Empty:
             pass
 
+        # Take the last sample published by each publisher from their queues
+        # ('last_sample_saved[i]') and save them local variables.
         try:
             last_first_sample = last_sample_saved[0].get(block=False)
         except queue.Empty:
@@ -138,10 +140,13 @@ def test_ownership_receivers(child_sub, samples_sent, last_sample_saved, timeout
                 break
             if last_second_sample in list_samples_processed:
                 break
+            print(f'Last samples: {last_first_sample}, {last_second_sample}')
             # Otherwise, wait a bit and continue
             time.sleep(0.1)
             continue
 
+        # Keep all samples processed in a single list, so we can check whether
+        # the last sample published by any publisher has already been processed
         list_samples_processed.append(sub_string.group(0))
 
         # If the app hit this point, it is because the previous subscriber


### PR DESCRIPTION
The check function for the ownership test loops till `MAX_SAMPLES_READ` samples have been processed.
Those samples should be from the list of published samples stored for each publisher.

In some cases where `VOLATILE` durability is used, the subscriber might miss the first published samples, which leads to a deadlock in the test (it continuously insists in continuing the loop [here](https://github.com/omg-dds/dds-rtps/blob/b57f91e6aa1f5bfd41e7e804854e0cd52081d095/test_suite.py#L121))

This PR introduces a mechanism where the publishers communicate the last sample saved in their multiprocess queue.
The check function can then break the loop if one of those samples has already been processed (i.e. it knows the publisher will not be adding elements to the muliprocess queue).

I checked it [here](https://github.com/eProsima/dds-rtps/actions/runs/11402580991) with the binary I have prepared for the last release of Fast DDS, and the latest one for Connext DDS