### PR TITLE
Parallelize run interoperability tests

### DIFF
--- a/.github/workflows/1_run_interoperability_tests.yml
+++ b/.github/workflows/1_run_interoperability_tests.yml
@@ -7,6 +7,10 @@ on:
         description: Publishers to use
         type: string
         default: '["connext_dds","dust_dds","eprosima_fastdds","intercom_dds","opendds","toc_coredx_dds"]'
+      subscribers:
+        description: Subscribers to use
+        type: string
+        default: '["connext_dds","dust_dds","eprosima_fastdds","intercom_dds","opendds","toc_coredx_dds"]'
 jobs:
   generate_timestamp:
     runs-on: ubuntu-latest
@@ -26,7 +30,7 @@ jobs:
     strategy:
       matrix:
         publisher: ${{ fromJson(github.event.inputs.publishers) }}
-        subscriber: [connext_dds, dust_dds, eprosima_fastdds, intercom_dds, opendds, toc_coredx_dds]
+        subscriber: ${{ fromJson(github.event.inputs.subscribers) }}
 
     steps:
     - name: Checkout sources

--- a/.github/workflows/1_run_interoperability_tests.yml
+++ b/.github/workflows/1_run_interoperability_tests.yml
@@ -73,6 +73,11 @@ jobs:
         run: junitparser merge *.xml junit_interoperability_report.xml
       - name: Generate xlsx report
         run: python3 generate_xlsx_report.py --input junit_interoperability_report.xml --output interoperability_report.xlsx
+      - name: XUnit
+        uses: AutoModality/action-xunit-viewer@v1
+        with:
+          results: ./junit_interoperability_report.xml
+          fail: false
       - name: Download timestamp
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/1_run_interoperability_tests.yml
+++ b/.github/workflows/1_run_interoperability_tests.yml
@@ -19,8 +19,8 @@ jobs:
     needs: generate_timestamp
     strategy:
       matrix:
-        publisher: [connext_dds, dust_dds, eprosima_fastdds, intercom_dds, opendds, toc_coredx_dds]
-        subscriber: [connext_dds, dust_dds, eprosima_fastdds, intercom_dds, opendds, toc_coredx_dds]
+        publisher: [dust_dds, eprosima_fastdds] #[connext_dds, dust_dds, eprosima_fastdds, intercom_dds, opendds, toc_coredx_dds]
+        subscriber: [dust_dds, eprosima_fastdds] #[connext_dds, dust_dds, eprosima_fastdds, intercom_dds, opendds, toc_coredx_dds]
 
     steps:
     - name: Checkout sources
@@ -41,7 +41,7 @@ jobs:
       run: pip install --requirement requirements.txt
     - name: Run Interoperability script
       timeout-minutes: 30
-      run: python3 interoperability_report.py --verbose --publisher executables/${{ matrix.publisher }}*shape_main_linux --subscriber executables/${{ matrix.subscriber }}*shape_main_linux --output-name junit_report-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml
+      run: python3 interoperability_report.py --publisher executables/${{ matrix.publisher }}*shape_main_linux --subscriber executables/${{ matrix.subscriber }}*shape_main_linux --output-name junit_report-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml
     - name: Download timestamp
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/1_run_interoperability_tests.yml
+++ b/.github/workflows/1_run_interoperability_tests.yml
@@ -19,7 +19,7 @@ jobs:
     needs: generate_timestamp
     strategy:
       matrix:
-        publisher: [connext_dds, dust_dds, eprosima_fastdds, intercom_dds, opendds, toc_coredx_dds]
+        publisher: ${{ fromJson(github.event.inputs.publishers || '["connext_dds","dust_dds","eprosima_fastdds","intercom_dds","opendds","toc_coredx_dds"]') }}
         subscriber: [connext_dds, dust_dds, eprosima_fastdds, intercom_dds, opendds, toc_coredx_dds]
 
     steps:

--- a/.github/workflows/1_run_interoperability_tests.yml
+++ b/.github/workflows/1_run_interoperability_tests.yml
@@ -1,19 +1,18 @@
 name: 1 - Run Interoperability Tests
-run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+run-name: Run Interoperability Tests by ${{ github.actor }}
 on: workflow_dispatch
 jobs:
   generate_timestamp:
     runs-on: ubuntu-latest
     steps:
-      - name: Generate timestamp file
-        run: date '+%Y-%m-%d-%H_%M_%S' > timestamp
-      - name: Attach the report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: timestamp
-          path: |
-            ./timestamp
+    - name: Generate timestamp file
+      run: date '+%Y-%m-%d-%H_%M_%S' > timestamp
+    - name: Upload timestamp file
+      uses: actions/upload-artifact@v4
+      with:
+        name: timestamp
+        path: |
+          ./timestamp
 
   run_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/1_run_interoperability_tests.yml
+++ b/.github/workflows/1_run_interoperability_tests.yml
@@ -14,327 +14,70 @@ jobs:
           name: timestamp
           path: |
             ./timestamp
-  connext_dds:
+
+  run_tests:
     runs-on: ubuntu-latest
     needs: generate_timestamp
+    strategy:
+      matrix:
+        publisher: [connext_dds, dust_dds, eprosima_fastdds, intercom_dds, opendds, toc_coredx_dds]
+        subscriber: [connext_dds, dust_dds, eprosima_fastdds, intercom_dds, opendds, toc_coredx_dds]
+
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11.4'
+    - name: Download shape_main executables
+      uses: robinraju/release-downloader@v1.10
+      with:
+        latest: true
+        fileName: "*"
+        out-file-path: zipped_executables
+    - name: Unzip executables
+      run: unzip 'zipped_executables/*.zip' -d executables
+    - name: Install Python requirements
+      run: pip install --requirement omg-dds-rtps/requirements.txt
+    - name: Run Interoperability script
+      timeout-minutes: 30
+      run: python3 ./omg-dds-rtps/interoperability_report.py --verbose --publisher ./executables/${{ matrix.publisher }}*shape_main_linux --subscriber ./executables/${{ matrix.subscriber }}*shape_main_linux --output-name junit_report-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml
+    - name: Download timestamp
+      uses: actions/download-artifact@v4
+      with:
+        name: timestamp
+    - name: Upload report
+      uses: actions/upload-artifact@v4
+      with:
+        name: junit_report-${{ matrix.publisher }}-${{ matrix.subscriber }}
+        path: |
+          ./junit_report-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml
+          ./timestamp
+
+  generate_report:
+    runs-on: ubuntu-latest
+    needs: run_tests
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: junit_report-*
+          merge-multiple: true
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11.4'
-      - name: Download artifact
+      - name: Install Python requirements
+        run: pip install --requirement requirements.txt
+      - name: merge reports
+        run: junitparser merge *.xml junit_interoperability_report.xml
+      - name: Generate xlsx report
+        run: python3 generate_xlsx_report.py --input junit_interoperability_report.xml --output interoperability_report.xlsx
+      - name: Download timestamp
         uses: actions/download-artifact@v4
         with:
           name: timestamp
-      - name: Downloads assets
-        uses: robinraju/release-downloader@v1.10
-        with:
-          latest: true
-          fileName: "*"
-      - name: Unzip
-        run: unzip '*.zip' -d executables
-      - name: Setting up environment
-        run: |
-          python3 -m venv .venv
-          source .venv/bin/activate
-          pip install -r requirements.txt
-      - name: Run Interoperability script
-        # The test descriptions used are the generated for the last execution.
-        # This shouldn't be an issue because all test are run always
-        run: |
-          source .venv/bin/activate
-          cd executables
-          for publisher in connext_dds-* ; do \
-            for subscriber in * ; do \
-              echo "Testing Publisher $publisher --- Subscriber $subscriber"; \
-              python3 ./../interoperability_report.py -P ./$publisher -S ./$subscriber -o=./../junit_interoperability_report.xml; \
-              if [ -d "./OpenDDS-durable-data-dir" ]; then \
-                echo Deleting OpenDDS-durable-data-dir; \
-                rm -rf ./OpenDDS-durable-data-dir; \
-              fi; \
-            done \
-          done
-      - name: Attach the report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: interoperability_report_connext_dds
-          path: |
-            ./junit_interoperability_report.xml
-            ./timestamp
-  dust_dds:
-    runs-on: ubuntu-latest
-    needs: connext_dds
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: interoperability_report_connext_dds
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11.4'
-      - name: Downloads assets
-        uses: robinraju/release-downloader@v1.10
-        with:
-          latest: true
-          fileName: "*"
-      - name: Unzip
-        run: unzip '*.zip' -d executables
-      - name: Setting up environment
-        run: |
-          python3 -m venv .venv
-          source .venv/bin/activate
-          pip install -r requirements.txt
-      - name: Run Interoperability script
-        # The test descriptions used are the generated for the last execution.
-        # This shouldn't be an issue because all test are run always
-        run: |
-          source .venv/bin/activate
-          cd executables
-          for publisher in dust_dds-* ; do \
-            for subscriber in * ; do \
-              echo "Testing Publisher $publisher --- Subscriber $subscriber"; \
-              python3 ./../interoperability_report.py -P ./$publisher -S ./$subscriber -o=./../junit_interoperability_report.xml; \
-              if [ -d "./OpenDDS-durable-data-dir" ]; then \
-                echo Deleting OpenDDS-durable-data-dir; \
-                rm -rf ./OpenDDS-durable-data-dir; \
-              fi; \
-            done \
-          done
-      - name: Attach the report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: interoperability_report_dust_dds
-          path: |
-            ./junit_interoperability_report.xml
-            ./timestamp
-  eprosima_fastdds:
-    runs-on: ubuntu-latest
-    needs: dust_dds
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: interoperability_report_dust_dds
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11.4'
-      - name: Downloads assets
-        uses: robinraju/release-downloader@v1.10
-        with:
-          latest: true
-          fileName: "*"
-      - name: Unzip
-        run: unzip '*.zip' -d executables
-      - name: Setting up environment
-        run: |
-          python3 -m venv .venv
-          source .venv/bin/activate
-          pip install -r requirements.txt
-      - name: Run Interoperability script
-        # The test descriptions used are the generated for the last execution.
-        # This shouldn't be an issue because all test are run always
-        run: |
-          source .venv/bin/activate
-          cd executables
-          for publisher in eprosima_fastdds-* ; do \
-            for subscriber in * ; do \
-              echo "Testing Publisher $publisher --- Subscriber $subscriber"; \
-              python3 ./../interoperability_report.py -P ./$publisher -S ./$subscriber -o=./../junit_interoperability_report.xml; \
-              if [ -d "./OpenDDS-durable-data-dir" ]; then \
-                echo Deleting OpenDDS-durable-data-dir; \
-                rm -rf ./OpenDDS-durable-data-dir; \
-              fi; \
-            done \
-          done
-      - name: Attach the report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: interoperability_report_eprosima_fastdds
-          path: |
-            ./junit_interoperability_report.xml
-            ./timestamp
-  intercom_dds:
-    runs-on: ubuntu-latest
-    needs: eprosima_fastdds
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: interoperability_report_eprosima_fastdds
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11.4'
-      - name: Downloads assets
-        uses: robinraju/release-downloader@v1.10
-        with:
-          latest: true
-          fileName: "*"
-      - name: Unzip
-        run: unzip '*.zip' -d executables
-      - name: Setting up environment
-        run: |
-          python3 -m venv .venv
-          source .venv/bin/activate
-          pip install -r requirements.txt
-      - name: Run Interoperability script
-        # The test descriptions used are the generated for the last execution.
-        # This shouldn't be an issue because all test are run always
-        run: |
-          source .venv/bin/activate
-          cd executables
-          for publisher in intercom_dds-* ; do \
-            for subscriber in * ; do \
-              echo "Testing Publisher $publisher --- Subscriber $subscriber"; \
-              python3 ./../interoperability_report.py -P ./$publisher -S ./$subscriber -o=./../junit_interoperability_report.xml; \
-              if [ -d "./OpenDDS-durable-data-dir" ]; then \
-                echo Deleting OpenDDS-durable-data-dir; \
-                rm -rf ./OpenDDS-durable-data-dir; \
-              fi; \
-            done \
-          done
-      - name: Attach the report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: interoperability_report_intercom_dds
-          path: |
-            ./junit_interoperability_report.xml
-            ./timestamp
-  opendds:
-    runs-on: ubuntu-latest
-    needs: intercom_dds
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: interoperability_report_intercom_dds
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11.4'
-      - name: Downloads assets
-        uses: robinraju/release-downloader@v1.10
-        with:
-          latest: true
-          fileName: "*"
-      - name: Unzip
-        run: unzip '*.zip' -d executables
-      - name: Setting up environment
-        run: |
-          python3 -m venv .venv
-          source .venv/bin/activate
-          pip install -r requirements.txt
-      - name: Run Interoperability script
-        # The test descriptions used are the generated for the last execution.
-        # This shouldn't be an issue because all test are run always
-        run: |
-          source .venv/bin/activate
-          cd executables
-          for publisher in opendds-* ; do \
-            for subscriber in * ; do \
-              echo "Testing Publisher $publisher --- Subscriber $subscriber"; \
-              python3 ./../interoperability_report.py -P ./$publisher -S ./$subscriber -o=./../junit_interoperability_report.xml; \
-              if [ -d "./OpenDDS-durable-data-dir" ]; then \
-                echo Deleting OpenDDS-durable-data-dir; \
-                rm -rf ./OpenDDS-durable-data-dir; \
-              fi; \
-            done \
-          done
-      - name: Attach the report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: interoperability_report_opendds
-          path: |
-            ./junit_interoperability_report.xml
-            ./timestamp
-  toc_coredx_dds:
-    runs-on: ubuntu-latest
-    needs: opendds
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: interoperability_report_opendds
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11.4'
-      - name: Downloads assets
-        uses: robinraju/release-downloader@v1.10
-        with:
-          latest: true
-          fileName: "*"
-      - name: Unzip
-        run: unzip '*.zip' -d executables
-      - name: Setting up environment
-        run: |
-          python3 -m venv .venv
-          source .venv/bin/activate
-          pip install -r requirements.txt
-      - name: Run Interoperability script
-        # The test descriptions used are the generated for the last execution.
-        # This shouldn't be an issue because all test are run always
-        run: |
-          source .venv/bin/activate
-          cd executables
-          for publisher in toc_coredx_dds-* ; do \
-            for subscriber in * ; do \
-              echo "Testing Publisher $publisher --- Subscriber $subscriber"; \
-              python3 ./../interoperability_report.py -P ./$publisher -S ./$subscriber -o=./../junit_interoperability_report.xml; \
-              if [ -d "./OpenDDS-durable-data-dir" ]; then \
-                echo Deleting OpenDDS-durable-data-dir; \
-                rm -rf ./OpenDDS-durable-data-dir; \
-              fi; \
-            done \
-          done
-      - name: Attach the report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: interoperability_report_toc_coredx_dds
-          path: |
-            ./junit_interoperability_report.xml
-            ./timestamp
-  generate_report:
-    runs-on: ubuntu-latest
-    needs: toc_coredx_dds
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: interoperability_report_toc_coredx_dds
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11.4'
-      - name: Setting up environment
-        run: |
-          python3 -m venv .venv
-          source .venv/bin/activate
-          pip install -r requirements.txt
-      - name: Generate xlsx report
-        run: |
-          source .venv/bin/activate
-          python3 generate_xlsx_report.py --input junit_interoperability_report.xml --output interoperability_report.xlsx
-      - name: XUnit Viewer
-        id: xunit-viewer
-        uses: AutoModality/action-xunit-viewer@v1
-        with:
-          results: ./junit_interoperability_report.xml
       - name: Attach the report
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/1_run_interoperability_tests.yml
+++ b/.github/workflows/1_run_interoperability_tests.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Download shape_main executables
       uses: robinraju/release-downloader@v1.10
       with:
+        repository: omg-dds/dds-rtps
         latest: true
         fileName: "*"
         out-file-path: zipped_executables

--- a/.github/workflows/1_run_interoperability_tests.yml
+++ b/.github/workflows/1_run_interoperability_tests.yml
@@ -1,5 +1,5 @@
 name: 1 - Run Interoperability Tests
-run-name: Run Interoperability Tests by ${{ github.actor }}
+run-name: Run Interoperability Tests
 on: workflow_dispatch
 jobs:
   generate_timestamp:
@@ -19,8 +19,8 @@ jobs:
     needs: generate_timestamp
     strategy:
       matrix:
-        publisher: [dust_dds, eprosima_fastdds] #[connext_dds, dust_dds, eprosima_fastdds, intercom_dds, opendds, toc_coredx_dds]
-        subscriber: [dust_dds, eprosima_fastdds] #[connext_dds, dust_dds, eprosima_fastdds, intercom_dds, opendds, toc_coredx_dds]
+        publisher: [connext_dds, dust_dds, eprosima_fastdds, intercom_dds, opendds, toc_coredx_dds]
+        subscriber: [connext_dds, dust_dds, eprosima_fastdds, intercom_dds, opendds, toc_coredx_dds]
 
     steps:
     - name: Checkout sources
@@ -40,7 +40,7 @@ jobs:
     - name: Install Python requirements
       run: pip install --requirement requirements.txt
     - name: Run Interoperability script
-      timeout-minutes: 30
+      timeout-minutes: 60
       run: python3 interoperability_report.py --publisher executables/${{ matrix.publisher }}*shape_main_linux --subscriber executables/${{ matrix.subscriber }}*shape_main_linux --output-name junit_report-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml
     - name: Download timestamp
       uses: actions/download-artifact@v4

--- a/.github/workflows/1_run_interoperability_tests.yml
+++ b/.github/workflows/1_run_interoperability_tests.yml
@@ -38,10 +38,10 @@ jobs:
     - name: Unzip executables
       run: unzip 'zipped_executables/*.zip' -d executables
     - name: Install Python requirements
-      run: pip install --requirement omg-dds-rtps/requirements.txt
+      run: pip install --requirement requirements.txt
     - name: Run Interoperability script
       timeout-minutes: 30
-      run: python3 ./omg-dds-rtps/interoperability_report.py --verbose --publisher ./executables/${{ matrix.publisher }}*shape_main_linux --subscriber ./executables/${{ matrix.subscriber }}*shape_main_linux --output-name junit_report-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml
+      run: python3 interoperability_report.py --verbose --publisher executables/${{ matrix.publisher }}*shape_main_linux --subscriber executables/${{ matrix.subscriber }}*shape_main_linux --output-name junit_report-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml
     - name: Download timestamp
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/1_run_interoperability_tests.yml
+++ b/.github/workflows/1_run_interoperability_tests.yml
@@ -1,6 +1,12 @@
 name: 1 - Run Interoperability Tests
 run-name: Run Interoperability Tests
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      publishers:
+        description: Publishers to use
+        type: string
+        default: '["connext_dds","dust_dds","eprosima_fastdds","intercom_dds","opendds","toc_coredx_dds"]'
 jobs:
   generate_timestamp:
     runs-on: ubuntu-latest
@@ -19,7 +25,7 @@ jobs:
     needs: generate_timestamp
     strategy:
       matrix:
-        publisher: ${{ fromJson(github.event.inputs.publishers || '["connext_dds","dust_dds","eprosima_fastdds","intercom_dds","opendds","toc_coredx_dds"]') }}
+        publisher: ${{ fromJson(github.event.inputs.publishers) }}
         subscriber: [connext_dds, dust_dds, eprosima_fastdds, intercom_dds, opendds, toc_coredx_dds]
 
     steps:


### PR DESCRIPTION
The execution of the interoperability tests takes at the moment more then 5 hours. To speed that up the tests are run in parallel using the matrix strategy where each publisher is run against each subscriber. This takes roughly 50 minutes which is the slowest combination (opendds -> connext_dds). Normally the run would be finished after 20 minutes.
The run can still be issued manually only. When starting the workflow the user can deselect publishers and/or subscribers. 
The matrix strategy also avoids code of cleaning up and avoids setting up a virtual Python environment all the time since every run is run an a fresh system. It also avoid code duplication since the run code needs to be written only once. Here is a run: https://github.com/s2e-systems/dds-rtps/actions/runs/19710790908 