### PR TITLE
Disable Type propagation of Fast DDS

### DIFF
--- a/doc/test_description.template.rst
+++ b/doc/test_description.template.rst
@@ -70,6 +70,7 @@ product versions.
 
   * Content Filtered Topic expression created with single quotes around strings
     values
+  * Type Propagation property set to "disabled"
 
 * **InterCOM DDS**:
 

--- a/srcCxx/shape_configurator_eprosima_fast_dds.h
+++ b/srcCxx/shape_configurator_eprosima_fast_dds.h
@@ -32,6 +32,13 @@
 namespace DDS = eprosima::fastdds::dds;
 #define RETCODE_OK DDS::RETCODE_OK
 
+void configure_fastdds_dp_qos(DDS::DomainParticipantQos &dp_qos)
+{
+    dp_qos.properties().properties().emplace_back(
+        "fastdds.type_propagation",
+        "disabled");
+}
+
 const char* get_qos_policy_name(DDS::QosPolicyId_t policy_id)
 {
   switch (policy_id) {

--- a/srcCxx/shape_main.cxx
+++ b/srcCxx/shape_main.cxx
@@ -1219,6 +1219,10 @@ public:
         configure_participant_announcements_period(dp_qos, options->periodic_announcement_period_us);
 #endif
 
+#ifdef EPROSIMA_FAST_DDS
+        configure_fastdds_dp_qos(dp_qos);
+#endif
+
         if (options->datafrag_size > 0) {
             bool result = false;
   #if defined(RTI_CONNEXT_DDS)


### PR DESCRIPTION
This PR disables Type propagation of Fast DDS by adding a Property to the Domain Participant QoS when Fast DDS is defined